### PR TITLE
Amazon Basics 5 Port HDMI Switcher

### DIFF
--- a/database/categories/A_V_receiver/Amazon/5PortHDMI.ir
+++ b/database/categories/A_V_receiver/Amazon/5PortHDMI.ir
@@ -1,0 +1,50 @@
+Filetype: IR signals file
+Version: 1
+# 
+name: power
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 03 00 00 00
+# 
+name: hdmi+
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 08 00 00 00
+# 
+name: hdmi-
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 06 00 00 00
+# 
+name: hdmi1
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 09 00 00 00
+# 
+name: hdmi2
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 0B 00 00 00
+# 
+name: hdmi3
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 0C 00 00 00
+# 
+name: hdmi4
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 0D 00 00 00
+# 
+name: hdmi5
+type: parsed
+protocol: NEC
+address: 00 00 00 00
+command: 0E 00 00 00


### PR DESCRIPTION
Amazon Basics branded multi-port HDMI splitter. Oddly my order history lists and links [a 3 port type](https://www.amazon.com/dp/B079LFMCMH), but I have a 5 port switcher. Probably to do with model options for a single "product", and behaviors for when a product is no longer sold on Amazon? Who knows. They appear to have retired this Basics option.

Would be neat if anyone reading this could verify that the Input 1/2/3 button codes on the 3-port model are the same as Inputs 1/2/3 in this file.

One organization question; Should "Basics" be in the folder name too?